### PR TITLE
[BACK,FRONT] jwt 토큰 쿠키적용 

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -14,6 +14,7 @@
         "antd": "^4.16.11",
         "axios": "^0.21.1",
         "react": "^17.0.2",
+        "react-cookies": "^0.1.1",
         "react-dom": "^17.0.2",
         "react-scripts": "4.0.3",
         "recoil": "^0.4.0",
@@ -15689,6 +15690,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-cookies": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookies/-/react-cookies-0.1.1.tgz",
+      "integrity": "sha512-PP75kJ4vtoHuuTdq0TAD3RmlAv7vuDQh9fkC4oDlhntgs9vX1DmREomO0Y1mcQKR9nMZ6/zxoflaMJ3MAmF5KQ==",
+      "dependencies": {
+        "cookie": "^0.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/react-cookies/node_modules/cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/react-dev-utils": {
@@ -33458,6 +33476,22 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.7",
         "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "react-cookies": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookies/-/react-cookies-0.1.1.tgz",
+      "integrity": "sha512-PP75kJ4vtoHuuTdq0TAD3RmlAv7vuDQh9fkC4oDlhntgs9vX1DmREomO0Y1mcQKR9nMZ6/zxoflaMJ3MAmF5KQ==",
+      "requires": {
+        "cookie": "^0.3.1",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
       }
     },
     "react-dev-utils": {

--- a/front/package.json
+++ b/front/package.json
@@ -9,6 +9,7 @@
     "antd": "^4.16.11",
     "axios": "^0.21.1",
     "react": "^17.0.2",
+    "react-cookies": "^0.1.1",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
     "recoil": "^0.4.0",

--- a/front/src/atom.js
+++ b/front/src/atom.js
@@ -1,5 +1,10 @@
 import { atom } from 'recoil';
 
+export const tokenState = atom({
+  key: 'token',
+  default: null,
+});
+
 export const guState = atom({
   key: 'gu',
   default: [],

--- a/front/src/screens/HotPlaceMapScreen.js
+++ b/front/src/screens/HotPlaceMapScreen.js
@@ -7,10 +7,43 @@ import KAKAO_LOGIN_SHORT from '../assets/KAKAO_LOGIN_SHORT.png';
 import NAVER_LOGIN from '../assets/NAVER_LOGIN.png';
 
 import LoginButton from '../utils/LoginButton';
+import { useRecoilState } from 'recoil';
+import { tokenState } from '../atom';
+import { getAllCookie, getCookie } from '../utils/CookieUtils';
 
 const { Content } = Layout;
+const { REACT_APP_TOKEN_KEY } = process.env;
 
 const HotPlaceMapScreen = () => {
+  const [token, setToken] = useRecoilState(tokenState);
+
+  useEffect(() => {
+    const authToken = getCookie(REACT_APP_TOKEN_KEY);
+    console.log(`파싱 결과 : authToken is ${authToken}`);
+
+    if (authToken != null) {
+      setToken(authToken);
+    }
+
+    //추후 에 없어질 코드
+    const allCookies = getAllCookie();
+    console.log('show all cookies!!!');
+    console.log(allCookies);
+
+    //추후 에 없어질 코드 end/
+  }, []);
+
+  useEffect(() => {
+    if (token != null) {
+      console.log(
+        'recoil 변수 token 의 값이 변경되었기 떄문에 나오는 로그입니다'
+      );
+      console.log(`recoil 변수 token is ${token}`);
+
+      console.log('여기서 사용자의 정보를 받아오는 API 연결');
+    }
+  }, [token]);
+
   return (
     <Layout style={{ height: '100vh' }}>
       <SiderBar></SiderBar>

--- a/front/src/utils/CookieUtils.js
+++ b/front/src/utils/CookieUtils.js
@@ -1,0 +1,13 @@
+import cookie from 'react-cookies';
+
+export const getCookie = (name) => {
+  const token = cookie.load(name);
+  if (token !== null && token !== undefined) {
+    return token;
+  }
+  return null;
+};
+
+export const getAllCookie = () => {
+  return cookie.loadAll();
+};

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -3695,6 +3695,11 @@
   "resolved" "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   "version" "1.0.6"
 
+"cookie@^0.3.1":
+  "integrity" "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+  "resolved" "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+  "version" "0.3.1"
+
 "cookie@0.4.0":
   "integrity" "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
   "resolved" "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz"
@@ -9658,6 +9663,14 @@
     "raf" "^3.4.1"
     "regenerator-runtime" "^0.13.7"
     "whatwg-fetch" "^3.4.1"
+
+"react-cookies@^0.1.1":
+  "integrity" "sha512-PP75kJ4vtoHuuTdq0TAD3RmlAv7vuDQh9fkC4oDlhntgs9vX1DmREomO0Y1mcQKR9nMZ6/zxoflaMJ3MAmF5KQ=="
+  "resolved" "https://registry.npmjs.org/react-cookies/-/react-cookies-0.1.1.tgz"
+  "version" "0.1.1"
+  dependencies:
+    "cookie" "^0.3.1"
+    "object-assign" "^4.1.1"
 
 "react-dev-utils@^11.0.3":
   "integrity" "sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A=="

--- a/web-server/api/src/main/java/com/hotplace/api/config/WebMvcConfig.java
+++ b/web-server/api/src/main/java/com/hotplace/api/config/WebMvcConfig.java
@@ -10,7 +10,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:8080/**","https://accounts.kakao.com/**");
+                .allowedOrigins("http://localhost:8080/**",
+                        "https://accounts.kakao.com/**",
+                        "http://localhost:3000/**",
+                        "http://localhost:3000");
     }
 
 }

--- a/web-server/api/src/main/java/com/hotplace/api/security/config/SecurityConfig.java
+++ b/web-server/api/src/main/java/com/hotplace/api/security/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.hotplace.api.security.config;
 
 import com.hotplace.api.security.filter.JwtAuthenticationFilter;
+import com.hotplace.api.security.handler.CustomOAuth2SuccessHandler;
 import com.hotplace.api.security.handler.OAuth2CustomSuccessHandler;
 import com.hotplace.api.security.provider.CustomOAuth2Provider;
 import com.hotplace.api.security.service.CustomOAuth2UserService;
@@ -26,6 +27,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     public final CustomOAuth2UserService customOAuth2UserService;
     public final OAuth2CustomSuccessHandler oAuth2CustomSuccessHandler;
     public final JwtAuthenticationFilter jwtAuthenticationFilter;
+    public final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -40,7 +42,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .headers().frameOptions().disable() // h2화면 보이게 처리
             .and()
                 .authorizeRequests() // url 권한 관리
-                .antMatchers("/", "/oauth2/**", "/h2-console/**","/login/oauth2/code/kakao/*","/oauth2Login","/login/oauth2/*" ,"/h2-console","/api/**","/index","/static/**","/login/oauth2/**")
+                .antMatchers("/login/oauth2/code/kakao").permitAll()
+                .antMatchers("/", "/oauth2/**", "/h2-console/**","/oauth2Login","/login/oauth2/*" ,"/h2-console","/api/**","/index","/static/**","/login/oauth2/**")
                 .permitAll()
                 .anyRequest().authenticated() // 위 주소 뺀 나머지 인증과정 거침
             .and()
@@ -48,7 +51,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .userInfoEndpoint()
                 .userService(customOAuth2UserService)
             .and()
-                .successHandler(oAuth2CustomSuccessHandler)
+                .successHandler(customOAuth2SuccessHandler)
             .and()
                 .addFilterBefore(jwtAuthenticationFilter, OAuth2LoginAuthenticationFilter.class);
 

--- a/web-server/api/src/main/java/com/hotplace/api/security/handler/CustomOAuth2SuccessHandler.java
+++ b/web-server/api/src/main/java/com/hotplace/api/security/handler/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,53 @@
+package com.hotplace.api.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hotplace.api.entity.User;
+import com.hotplace.api.repository.UserRepository;
+import com.hotplace.api.security.util.CookieUtils;
+import com.hotplace.api.security.util.JwtTokenUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenUtil jwtTokenUtil;
+    private final UserRepository userRepository;
+    private final CookieUtils cookieUtils;
+
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+
+        String providerId = oauth2User.getName();
+        logger.info("인증 성공? success handler provider id : " + providerId);
+
+        User user = userRepository.findByProviderId(providerId).orElseThrow(
+                () -> new AuthenticationCredentialsNotFoundException("회원이 존재하지 않습니다.")
+        );
+
+        String token = jwtTokenUtil.createToken(user.getId(), user.getProviderId());
+
+        //HttpOnly=false //REST_API 로 사용가능한 쿠키
+        response.addCookie(cookieUtils.generateNormalCookie("X-AUTH-TOKEN", token, 2000000000));
+
+        if (response.isCommitted()) { //redirect loop 방지
+            logger.debug("Response has already been committed. Unable to redirect.");
+            return;
+        }
+
+        getRedirectStrategy().sendRedirect(request,response,"/"); //root page 로 이동
+    }
+}

--- a/web-server/api/src/main/java/com/hotplace/api/security/util/CookieUtils.java
+++ b/web-server/api/src/main/java/com/hotplace/api/security/util/CookieUtils.java
@@ -1,0 +1,58 @@
+package com.hotplace.api.security.util;
+
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+
+@Component
+public class CookieUtils {
+
+    public Cookie generateCookie(String name, String value, String path, boolean httpOnly, int maxAge, String domain) {
+
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath(path);
+        cookie.setHttpOnly(httpOnly);
+        cookie.setMaxAge(maxAge); //sec
+        if (domain != null) {
+            cookie.setDomain(domain);
+        }
+
+        return cookie;
+    }
+
+    public Cookie generateJwtHttpOnlyCookie(String name, String value, int maxAge) {
+        Cookie cookieJwt = generateCookie(name, value, "/", true, maxAge, null);
+        return cookieJwt;
+    }
+
+    public Cookie generateNormalCookie(String name, String value, int maxAge) {
+        Cookie cookieJwt = generateCookie(name, value, "/", false, maxAge, null);
+        return cookieJwt;
+    }
+
+    public Cookie generateRemoveJwtCookie(String name, String value) {
+        Cookie cookieJwt = generateCookie(name, "", "/", true, 0, null);
+        return cookieJwt;
+    }
+
+
+    public String getcookieValue(HttpServletRequest request, String key) {
+
+        String value = "";
+
+        if (request.getCookies() != null ) {
+
+            for (Cookie cookie : request.getCookies()){
+                if (cookie.getName().equals(key)) {
+                    value = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        return value;
+    }
+
+}


### PR DESCRIPTION
# 소셜로그인 SPA 에서 구현

## 6602aaa / #91 
* SimpleUrlAuthenticationSuccessHandler 를 상속받아 구현한 구현체
* CookieUtil Component 추가
* SecurityConfig 파일 수정

###SecurityConfig.java 놓친 부분
```java
 .authorizeRequests() // url 권한 관리
                .antMatchers("/login/oauth2/code/kakao").permitAll()
                .antMatchers("/", "/oauth2/**", "/h2-console/**","/oauth2Login","/login/oauth2/*" ,"/h2-console","/api/**","/index","/static/**","/login/oauth2/**")
                .permitAll()
```
1. 이부분의 antMacher 중 몇개는 필요가 없어보임 
`/login/oauth2/code/kakao` 로 접속하는 부분은 열려있어야함

```java
public final OAuth2CustomSuccessHandler oAuth2CustomSuccessHandler;
```
2. 이부분 필요 없음

## 13741f1
* front dev 환경과 CORS 처리

### WebMvcConfig.java 놓친 부분
CORS 처리한 부분도 localhost:3000 만 open 해놓으면 될듯
kakao 저부분도 삭제가 해야됨


> 놓친 부분은 바꾸고 테스트 후 다시 커밋할 예정


## 4be1009
`npm i react-cookie -s` 의 결과

## 65ab12f / #93 
* SPA react 환경에서 쿠키 접근 및 로그로 확인
