### PR TITLE
Feature back oauth2

### DIFF
--- a/web-server/api/src/main/java/com/hotplace/api/controller/UserController.java
+++ b/web-server/api/src/main/java/com/hotplace/api/controller/UserController.java
@@ -1,0 +1,25 @@
+package com.hotplace.api.controller;
+
+import com.hotplace.api.dto.UserInfoResponse;
+import com.hotplace.api.dto.api_form.ApiForm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.hotplace.api.dto.api_form.ApiForm.succeed;
+
+@Slf4j
+@RequestMapping("/user")
+@RestController
+public class UserController {
+
+    @GetMapping("/info")
+    public ApiForm<UserInfoResponse> getUserInfo(@AuthenticationPrincipal OAuth2User oAuth2User){
+        log.info("user info controller");
+        return succeed(UserInfoResponse.toResponse(oAuth2User.getAttribute("user")),
+                "유저 정보 반환에 성공했습니다.");
+    }
+}

--- a/web-server/api/src/main/java/com/hotplace/api/dto/UserInfoResponse.java
+++ b/web-server/api/src/main/java/com/hotplace/api/dto/UserInfoResponse.java
@@ -1,0 +1,20 @@
+package com.hotplace.api.dto;
+
+import com.hotplace.api.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoResponse {
+    private String email;
+    private String name;
+    private String profileUrl;
+
+    public static UserInfoResponse toResponse (User user){
+        return new UserInfoResponse(user.getEmail(), user.getName(), user.getProfile());
+    }
+}

--- a/web-server/api/src/main/java/com/hotplace/api/security/config/SecurityConfig.java
+++ b/web-server/api/src/main/java/com/hotplace/api/security/config/SecurityConfig.java
@@ -57,18 +57,18 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     }
 
-    @Bean
-    public ClientRegistrationRepository clientRegistrationRepository(
-            @Value("${spring.security.oauth2.client.registration.kakao.client-id}") String kakaoClientId,
-            @Value("${spring.security.oauth2.client.registration.kakao.client-secret}") String kakaoClientSecret
-    ){
-        List<ClientRegistration> registrations = new ArrayList<>();
-        registrations.add(CustomOAuth2Provider.KAKAO.getBuilder("kakao")
-                .clientId(kakaoClientId)
-                .clientSecret(kakaoClientSecret)
-                .jwkSetUri("temp")
-                .build());
-
-        return new InMemoryClientRegistrationRepository(registrations);
-    }
+//    @Bean
+//    public ClientRegistrationRepository clientRegistrationRepository(
+//            @Value("${spring.security.oauth2.client.registration.kakao.client-id}") String kakaoClientId,
+//            @Value("${spring.security.oauth2.client.registration.kakao.client-secret}") String kakaoClientSecret
+//    ){
+//        List<ClientRegistration> registrations = new ArrayList<>();
+//        registrations.add(CustomOAuth2Provider.KAKAO.getBuilder("kakao")
+//                .clientId(kakaoClientId)
+//                .clientSecret(kakaoClientSecret)
+//                .jwkSetUri("temp")
+//                .build());
+//
+//        return new InMemoryClientRegistrationRepository(registrations);
+//    }
 }

--- a/web-server/api/src/main/java/com/hotplace/api/security/handler/CustomOAuth2SuccessHandler.java
+++ b/web-server/api/src/main/java/com/hotplace/api/security/handler/CustomOAuth2SuccessHandler.java
@@ -1,14 +1,13 @@
 package com.hotplace.api.security.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hotplace.api.entity.User;
 import com.hotplace.api.repository.UserRepository;
+import com.hotplace.api.security.service.PrincipalDetails;
 import com.hotplace.api.security.util.CookieUtils;
 import com.hotplace.api.security.util.JwtTokenUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -29,9 +28,9 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
 
-        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+        PrincipalDetails oauth2User = (PrincipalDetails) authentication.getPrincipal();
 
-        String providerId = oauth2User.getName();
+        String providerId = oauth2User.getUserProviderId();
         logger.info("인증 성공? success handler provider id : " + providerId);
 
         User user = userRepository.findByProviderId(providerId).orElseThrow(

--- a/web-server/api/src/main/java/com/hotplace/api/security/provider/CustomOAuth2Provider.java
+++ b/web-server/api/src/main/java/com/hotplace/api/security/provider/CustomOAuth2Provider.java
@@ -10,7 +10,7 @@ public enum CustomOAuth2Provider {
         public ClientRegistration.Builder getBuilder(String registrationId) {
             ClientRegistration.Builder builder = getBuilder(registrationId,
                     ClientAuthenticationMethod.POST, KAKAO_REDIRECT_URL)
-                    .scope("profile_image", "account_email")
+                    .scope("profile_image", "account_email", "profile_nickname")
                     .authorizationUri("https://kauth.kakao.com/oauth/authorize")
                     .tokenUri("https://kauth.kakao.com/oauth/token")
                     .userInfoUri("https://kapi.kakao.com/v2/user/me")

--- a/web-server/api/src/main/java/com/hotplace/api/security/service/OAuth2Attribute.java
+++ b/web-server/api/src/main/java/com/hotplace/api/security/service/OAuth2Attribute.java
@@ -1,0 +1,60 @@
+package com.hotplace.api.security.service;
+
+import com.hotplace.api.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@ToString
+public class OAuth2Attribute {
+    String profileUrl;
+    String name;
+    String email;
+    String registrationId;
+    String providerId;
+
+    public OAuth2Attribute(){}
+
+    public static OAuth2Attribute of(String registrationId, String providerId, Map<String, Object> attributes){
+        if (registrationId.equals("kakao")){
+            return ofKakao(registrationId, providerId, attributes);
+        }else{
+            return ofNaver(registrationId, providerId, attributes);
+        }
+    }
+
+    public static OAuth2Attribute ofKakao(String registrationId, String providerId, Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        return OAuth2Attribute.builder()
+                .profileUrl((String) ((LinkedHashMap<String, Object>)kakaoAccount.get("profile")).get("profile_image_url"))
+                .name((String) properties.get("nickname"))
+                .email((String) kakaoAccount.get("email"))
+                .registrationId(registrationId)
+                .providerId(providerId)
+                .build();
+    }
+
+    public static OAuth2Attribute ofNaver(String registrationId, String providerId, Map<String, Object> attributes) {
+        Map<String, Object> naverResponse = (Map<String, Object>) attributes.get("response");
+        return OAuth2Attribute.builder()
+                .profileUrl((String) naverResponse.get("profile_image"))
+                .name((String) naverResponse.get("name"))
+                .email((String) naverResponse.get("email"))
+                .registrationId(registrationId)
+                .providerId(providerId)
+                .build();
+    }
+
+    public User toEntity(){
+        return new User(null, profileUrl, name, email, registrationId, providerId);
+    }
+
+}

--- a/web-server/api/src/main/java/com/hotplace/api/security/service/OAuth2Attribute.java
+++ b/web-server/api/src/main/java/com/hotplace/api/security/service/OAuth2Attribute.java
@@ -22,34 +22,34 @@ public class OAuth2Attribute {
 
     public OAuth2Attribute(){}
 
-    public static OAuth2Attribute of(String registrationId, String providerId, Map<String, Object> attributes){
+    public static OAuth2Attribute of(String registrationId, Map<String, Object> attributes){
         if (registrationId.equals("kakao")){
-            return ofKakao(registrationId, providerId, attributes);
+            return ofKakao(registrationId, attributes);
         }else{
-            return ofNaver(registrationId, providerId, attributes);
+            return ofNaver(registrationId, attributes);
         }
     }
 
-    public static OAuth2Attribute ofKakao(String registrationId, String providerId, Map<String, Object> attributes) {
+    public static OAuth2Attribute ofKakao(String registrationId, Map<String, Object> attributes) {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
         return OAuth2Attribute.builder()
-                .profileUrl((String) ((LinkedHashMap<String, Object>)kakaoAccount.get("profile")).get("profile_image_url"))
-                .name((String) properties.get("nickname"))
-                .email((String) kakaoAccount.get("email"))
+                .profileUrl(String.valueOf(((Map<String, Object>) kakaoAccount.get("profile")).get("profile_image_url")))
+                .name(String.valueOf(properties.get("nickname")))
+                .email(String.valueOf(kakaoAccount.get("email")))
                 .registrationId(registrationId)
-                .providerId(providerId)
+                .providerId(String.valueOf(attributes.get("id")))
                 .build();
     }
 
-    public static OAuth2Attribute ofNaver(String registrationId, String providerId, Map<String, Object> attributes) {
+    public static OAuth2Attribute ofNaver(String registrationId, Map<String, Object> attributes) {
         Map<String, Object> naverResponse = (Map<String, Object>) attributes.get("response");
         return OAuth2Attribute.builder()
-                .profileUrl((String) naverResponse.get("profile_image"))
-                .name((String) naverResponse.get("name"))
-                .email((String) naverResponse.get("email"))
+                .profileUrl(String.valueOf(naverResponse.get("profile_image")))
+                .name(String.valueOf(naverResponse.get("name")))
+                .email(String.valueOf(naverResponse.get("email")))
                 .registrationId(registrationId)
-                .providerId(providerId)
+                .providerId((String) naverResponse.get("id"))
                 .build();
     }
 

--- a/web-server/api/src/main/java/com/hotplace/api/security/service/PrincipalDetails.java
+++ b/web-server/api/src/main/java/com/hotplace/api/security/service/PrincipalDetails.java
@@ -1,0 +1,39 @@
+package com.hotplace.api.security.service;
+
+import com.hotplace.api.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PrincipalDetails implements OAuth2User {
+
+    private User user;
+    private Map<String, Object> attributes;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return user.getName();
+    }
+
+    public String getUserProviderId(){
+        return user.getProviderId();
+    }
+}

--- a/web-server/api/src/test/java/com/hotplace/api/controller/UserControllerTest.java
+++ b/web-server/api/src/test/java/com/hotplace/api/controller/UserControllerTest.java
@@ -1,0 +1,64 @@
+package com.hotplace.api.controller;
+
+import com.hotplace.api.entity.User;
+import com.hotplace.api.repository.UserRepository;
+import com.hotplace.api.security.util.JwtTokenUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class UserControllerTest {
+
+    @Autowired private MockMvc mvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private JwtTokenUtil jwtTokenUtil;
+
+    @PostConstruct
+    void init(){
+        userRepository.save(new User(null, "www.profile/1", "kim", "kim@naver.com", "kakao", "1234"));
+        userRepository.save(new User(null, "www.profile/2", "seo", "seo@naver.com", "naver", "5678"));
+        userRepository.save(new User(null, "www.profile/lee", "lee", "lee@naver.com", "kakao", "9101"));
+    }
+
+    @DisplayName("1. 유저 정보 조회 테스트")
+    @Test
+    public void getUserInfo() throws Exception {
+        User userA = findUserByProviderId("1234");
+        String jwtToken = jwtTokenUtil.createToken(userA.getId(), userA.getProviderId());
+
+        mvc
+                .perform(get("/user/info")
+                .header("X-Auth-Token", jwtToken))
+            .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.email").value(userA.getEmail()))
+                .andExpect(jsonPath("$.data.name").value(userA.getName()))
+                .andExpect(jsonPath("$.data.profileUrl").value(userA.getProfile()));
+    }
+
+    public User findUserByProviderId(String providerId){
+        return userRepository.findByProviderId(providerId).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 유저입니다.")
+        );
+    }
+}


### PR DESCRIPTION

### e64b10f, 9bd1a21 (OAtuh2Attribute 객체 관련)

각 SNS에서 반환해주는 값인 Map<String, Object> attribute에서 우리가 필요한 값들을 정의해 놓은 객체.

Naver, Kakao 두 곳에서 반환해주는 api 스펙이 다르기 때문에 각각 생성자를 구현 해줌.
 -> **static method 인 of** 에서 registrationId를 통해 구분.

9bd1a21 : (String)을 통해 type casting을 해주기 보다는 정적 매소드를 통해 변경. 
providerId도 kakao, naver 다른 변수에 저장되어 있기 때문에 따로 파싱하여 저장.

### 77a4f04 (CustomOAuth2UserService)
SNS에서 받아오는 공통 속성들을 OAuth2Attribute 객체에 담음.
기존 Service에서 파싱했던 로직을 OAuth2Attribute 객체의 생성자에 위임.

### 4ccff12, fd5563d

CientRegistration.Builder로 작성했던 코드 -> .yml 설정으로 바꿔 줬음.


### 54e509f
처음 로직 -> oAuth2User 객체를 이용해서 getName() 매소드로 providerId 를 가져왔음.
하지만, kakao와 naver 각각 다른 값이 담겨오기 때문에 **OAuth2User 객체를 상속받은 PrincipalDetails** 객체를 구현해 해당 객체에서 providerId를 가져올 수 있게 구현함.

### d5518d2 (OAuth2User 상속 받은 PrincipalDetails 객체)
handler에서 활용하기 위해 생성

### d24aa4c

mockMvc를 활용해 user/info 요청 테스트



